### PR TITLE
Fix deploy secrets, branch naming, and issue labels

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -291,8 +291,9 @@ Do NOT commit code that would fail any of these checks. The CI workflow (`.githu
 Every effort — bug fix, feature, refactor, docs update — **must** have an associated GitHub Issue (work item). This is enforced by branch protection rules on `main`.
 
 - Before starting work, check if a relevant issue exists. If not, **create one** with `gh issue create`.
+- GitHub Issues **must** have a `bug` or `feature` label. Apply with `--label` flag.
 - Reference the issue in the PR (e.g., `Closes #42` or `Fixes #42` in the PR body).
-- Branch names **must** include the issue number (e.g., `42-fix-schedule-conflict`).
+- Branch names **must** use the format: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`.
 - Direct pushes to `main` are not allowed — all changes go through pull requests.
 
 ### Git workflow (REQUIRED)
@@ -300,12 +301,13 @@ Every effort — bug fix, feature, refactor, docs update — **must** have an as
 Branch policies are enforced on `main`. **Never commit directly to main.** Follow this workflow:
 
 ```bash
-# 1. Create or find a GitHub Issue
-gh issue create --title "Description of work"   # if none exists
+# 1. Create or find a GitHub Issue (with appropriate label)
+gh issue create --title "Description of work" --label "feature"   # or --label "bug"
 
-# 2. Create a feature branch (include issue number)
+# 2. Create a feature or fix branch (include issue number)
 git checkout main && git pull
-git checkout -b <issue-number>-<short-description>
+git checkout -b feature/<issue-number>-<short-description>   # for new features/enhancements
+git checkout -b fix/<issue-number>-<short-description>       # for bug fixes
 
 # 3. Make changes, validate locally (see CI gate compliance above)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
       id-token: write
       contents: read
     uses: ./.github/workflows/_deploy.yml
+    secrets: inherit
     with:
       environment: dev
       tf_var_file: env/dev.tfvars
@@ -37,6 +38,7 @@ jobs:
       id-token: write
       contents: read
     uses: ./.github/workflows/_deploy.yml
+    secrets: inherit
     with:
       environment: prod
       tf_var_file: env/prod.tfvars


### PR DESCRIPTION
Closes #1

## Changes
- Add \secrets: inherit\ to reusable deploy workflow calls (fixes empty credentials)
- Update branch naming convention to \eature/\ and \ix/\ prefixes
- Issues must have \ug\ or \eature\ label
- Restore missing terraform blocks in modules (fixes hashicorp/azapi resolution)
- Fix tflint warnings, move subscription IDs to tfvars
- Strengthen CI gate instructions